### PR TITLE
fix: handle non-JSON Blizzard API responses (#2)

### DIFF
--- a/src/Models/BlizAPIErrors.js
+++ b/src/Models/BlizAPIErrors.js
@@ -1,0 +1,10 @@
+import { model, Schema } from "mongoose";
+
+const errorSchema = new Schema({
+    url: String,
+    status: Number,
+    body: String
+}, { timestamps: true });
+
+const BlizAPIError = model("BlizAPIError", errorSchema);
+export default BlizAPIError;

--- a/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
+++ b/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
@@ -367,11 +367,13 @@ const helpFetch = {
                     console.warn(err)
                 }
 
-                await delay(1000); // Delay to give the API air
+                await delay(1000); // Delay to give the API air;
+                retries += 5
             }
         }
 
-        return fetch(apiUrl, finalOptions)
+        // return fetch(apiUrl, finalOptions);
+        return data;
     },
 
     getCharMedia: async function (href) {

--- a/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
+++ b/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
@@ -4,6 +4,7 @@ import {delay} from "../startBGTask.js";
 import Achievement from "../../Models/Achievements.js";
 import { getSeasonalIdsMap, setSeasonalIdsMap } from "../../caching/achievements/achievesEmt.js";
 import dotenv from 'dotenv';
+import BlizAPIError from "../../Models/BlizAPIErrors.js";
 dotenv.config({ path: '../../../.env' });
 
 const clientId = process.env.CLIENT_ID;
@@ -352,6 +353,20 @@ const helpFetch = {
                     data = JSON.parse(text);
                 }
             } catch (error) {
+
+                try {
+                    
+                    const newError = new BlizAPIError({
+                        url :url,
+                        status: res.status || 0,
+                        body : res?.body || text
+                    })
+                    await newError.save();
+
+                } catch (err) {
+                    console.warn(err)
+                }
+
                 await delay(1000); // Delay to give the API air
             }
         }

--- a/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
+++ b/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
@@ -47,7 +47,7 @@ const helpFetch = {
     getCharProfile: async function (server, realm , name) {
         const URI = `https://${server}.api.blizzard.com/profile/wow/character/${realm}/${name}?namespace=profile-${server}&locale=en_US`;
         try {
-            const data = await (await this.fetchBlizzard(URI)).json();
+            const data = await this.fetchBlizzard(URI);
             return data
         } catch (error) {
             console.log(error)
@@ -60,18 +60,18 @@ const helpFetch = {
         try {
 
             try {
-                data1 = await(await this.fetchBlizzard(data[path].key.href)).json();
+                data1 = await this.fetchBlizzard(data[path].key.href);
             } catch (error) {
                 await delay(500);
                 try {
-                    data1 = await(await this.fetchBlizzard(data[path].key.href)).json();
+                    data1 = await this.fetchBlizzard(data[path].key.href);
                 } catch (error) {
                     await delay(200);
-                    data1 = await(await this.fetchBlizzard(data[path].key.href)).json();
+                    data1 = await this.fetchBlizzard(data[path].key.href);
                 }
             }
             try {
-                const data2 = await ( await this.fetchBlizzard(data1.media.key.href)).json();
+                const data2 = await this.fetchBlizzard(data1.media.key.href);
                 return data2 ? data2.assets[0].value : undefined
                 
             } catch (error) {
@@ -102,7 +102,7 @@ const helpFetch = {
 
                 currentSeasonIndex = await this.getCurrentPvPSeasonIndex();  
             }
-            let brackets = (await (await this.fetchBlizzard(path)).json()).brackets;
+            let brackets = (await this.fetchBlizzard(path)).brackets;
             if (brackets == undefined) return {
                 solo: {
                 },
@@ -133,7 +133,7 @@ const helpFetch = {
                     lastSeasonLadder: undefined,
                 }
             }
-            const bracketFetches = brackets.map(bracket =>this.fetchBlizzard(bracket.href).then(res => { return  res.json()}));
+            const bracketFetches = brackets.map(bracket =>this.fetchBlizzard(bracket.href));
 
             const allBracketsData = await Promise.all(bracketFetches);
 
@@ -220,7 +220,7 @@ const helpFetch = {
         }
     },
     getPvPTitle: async function (href) {
-        let data = await (await this.fetchBlizzard(href)).json();
+        let data = await this.fetchBlizzard(href);
         try {
             if (data?.code == 404 ) return undefined;
             let result = {
@@ -244,7 +244,7 @@ const helpFetch = {
     getpastRate: async function (url, playerName) {
         let data;
         try {
-            data = await (await this.fetchBlizzard(url)).json()
+            data = await this.fetchBlizzard(url);
         } catch (error) {
             console.warn(`BAD FETCH`);
         }
@@ -268,7 +268,7 @@ const helpFetch = {
     getAchievById : async function (href, statId) {
         let data
         try {
-            data = await(await this.fetchBlizzard(href)).json();
+            data = await this.fetchBlizzard(href);
         } catch (error) {
             console.warn(`Error fetchng!`)
             return 0
@@ -287,7 +287,7 @@ const helpFetch = {
     getAchievXP: async function (href, points) {
         let data;
         try {
-            data = await (await helpFetch.fetchBlizzard(href)).json();
+            data = await helpFetch.fetchBlizzard(href);
 
             const achievementsMAP = new Map();
             const seasonalAchieves = [];
@@ -378,7 +378,7 @@ const helpFetch = {
 
     getCharMedia: async function (href) {
         try {
-            const data = (await( await helpFetch.fetchBlizzard(href)).json()).assets;
+            const data = (await helpFetch.fetchBlizzard(href)).assets;
             const assets = {
                 avatar: (data[0])[`value`] || "",
                 banner: (data[1])[`value`] || "",
@@ -392,7 +392,7 @@ const helpFetch = {
     },
     getCharGear: async function (href) {
         try {
-            const data = await (await this.fetchBlizzard(href)).json();
+            const data = await this.fetchBlizzard(href);
             const result = await formatGearData(data);
             return result
         } catch (error) {
@@ -401,7 +401,7 @@ const helpFetch = {
     },
     getStats: async function(href){
         try {
-            const data = await(await this.fetchBlizzard(href)).json();
+            const data = await this.fetchBlizzard(href);
             const result = extractStats(data);
             return result
         } catch (error) {
@@ -414,8 +414,7 @@ const helpFetch = {
 
         
         try {
-            const req = await this.fetchBlizzard(url);
-            const data = await req.json();
+            const data = await this.fetchBlizzard(url);
             const currentSeasonId = data?.current_season?.id;
 
             return currentSeasonId;
@@ -431,8 +430,7 @@ const helpFetch = {
         const guildServer = "eu"
         const path = `https://${guildServer}.api.blizzard.com/data/wow/guild/${guildRealmSlug}/${guildNameSlug}/roster?namespace=profile-${guildServer}`;
        
-        const req = await this.fetchBlizzard(path);
-        const data = await req.json();
+        const data = await this.fetchBlizzard(path);
 
         const memberList = data.members;
 
@@ -443,17 +441,17 @@ const helpFetch = {
         const result = {};
         try {
             
-            let req = await this.fetchBlizzard(href);
-            if (!req.ok) {
-                await delay(3000);
-                req = await this.fetchBlizzard(href);
-                if(!req.ok) {
-                    console.warn(`Active Spec Error response code : ${req.status}`)
-                }
-            }
+            const data = await this.fetchBlizzard(href);
+            // if (!req.ok) {
+            //     await delay(3000);
+            //     req = await this.fetchBlizzard(href);
+            //     if(!req.ok) {
+            //         console.warn(`Active Spec Error response code : ${req.status}`)
+            //     }
+            // }
             
-            if (req.ok) {
-                const data = await req.json();
+            // if (req.ok) {
+                // const data = await req.json();
                 const activeSpecTalent = data?.active_hero_talent_tree?.name;
                 const specId = data.active_specialization.id;
                 const activeSpecData = data.specializations.find(specDetails => specDetails.specialization.id == specId);
@@ -464,7 +462,7 @@ const helpFetch = {
                 result.talentsSpec = activeSpecTalent ? activeSpecTalent : null;
 
                 return result
-            } 
+            // } 
         } catch (error) {
             if (Object.keys(result).length === 0) return result
             console.warn(error);
@@ -477,15 +475,15 @@ const helpFetch = {
     },
     getTalentSpec: async function (href) {
         try {
-            const req = await this.fetchBlizzard(href);
+            const data = await this.fetchBlizzard(href);
             
-            if(req.ok){
-                const data = await req.json();
+            // if(req.ok){
+                // const data = await req.json();
                 const talentString = data?.active_hero_talent_tree?.name;
                 
                 return talentString ? talentString : null;
 
-            }
+            // }
         } catch (error) {
             console.warn(error);
         }
@@ -499,11 +497,11 @@ const helpFetch = {
         const url = `https://${server}.api.blizzard.com/data/wow/search/connected-realm?namespace=dynamic-${server}&orderby=id`;
 
         try {
-            const req = await this.fetchBlizzard(url);
-            if (req.ok) {
-                const data = await req.json();
+            const data = await this.fetchBlizzard(url);
+            // if (req.ok) {
+                // const data = await req.json();
                 return data?.results
-            }
+            // }
         } catch (error) {
             return null
         }
@@ -547,7 +545,7 @@ async function filterAchiev (achievements, points) {
         let match = achievements.get(dataID)
         if (match && match?.completed_timestamp){
             try {
-                const data = await(await helpFetch.fetchBlizzard(match.achievement.key.href)).json();
+                const data = await helpFetch.fetchBlizzard(match.achievement.key.href);
                 const twosResult = {
                     name: data.name,
                     description: data.description,
@@ -565,7 +563,7 @@ async function filterAchiev (achievements, points) {
         let match = achievements.get(dataID);
         if (match && match?.completed_timestamp){
             try {
-                const data = await(await helpFetch.fetchBlizzard(match.achievement.key.href)).json();
+                const data = await helpFetch.fetchBlizzard(match.achievement.key.href);
                 const threesResult = {
                     name: data.name,
                     description: data.description,
@@ -582,7 +580,7 @@ async function filterAchiev (achievements, points) {
     for (const {key, name, id: dataID} of achievesData["soloShuffle"]) {
         let match = achievements.get(dataID);
         if (match && match?.completed_timestamp) try {
-            const data = await(await helpFetch.fetchBlizzard(match.achievement.key.href)).json();
+            const data = await helpFetch.fetchBlizzard(match.achievement.key.href);
             const soloResult = {
                 name: data.name,
                 description: data.description,
@@ -598,7 +596,7 @@ async function filterAchiev (achievements, points) {
     for (const {key, name, id: dataID} of achievesData["BG"]) {
         let match = achievements.get(dataID);
         if (match && match?.completed_timestamp) try {
-            const data = await(await helpFetch.fetchBlizzard(match.achievement.key.href)).json();
+            const data = await helpFetch.fetchBlizzard(match.achievement.key.href);
             const BGXPResult = {
                 name: data.name,
                 description: data.description,
@@ -615,7 +613,7 @@ async function filterAchiev (achievements, points) {
     for (const {key, name, id: dataID} of achievesData["RBGWins"]) {
         let match = achievements.get(dataID);
         if (match && match?.completed_timestamp) try {
-            const data = await(await helpFetch.fetchBlizzard(match.achievement.key.href)).json();
+            const data = await helpFetch.fetchBlizzard(match.achievement.key.href);
             const RBGWinsResult = {
                 name: data.name,
                 description: data.description,
@@ -656,7 +654,7 @@ async function filterAchiev (achievements, points) {
         let match = achievements.get(dataID);
         if (match && match?.completed_timestamp)
             try {
-                const data = await(await helpFetch.fetchBlizzard(match.achievement.key.href)).json();
+                const data = await helpFetch.fetchBlizzard(match.achievement.key.href);
                 const BlitzWinsResult = {
                     name: data.name,
                     description: data.description,

--- a/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
+++ b/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
@@ -368,7 +368,7 @@ const helpFetch = {
                 }
 
                 await delay(1000); // Delay to give the API air;
-                retries += 5
+                retries += 1
             }
         }
 

--- a/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
+++ b/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
@@ -440,29 +440,18 @@ const helpFetch = {
 
         const result = {};
         try {
-            
             const data = await this.fetchBlizzard(href);
-            // if (!req.ok) {
-            //     await delay(3000);
-            //     req = await this.fetchBlizzard(href);
-            //     if(!req.ok) {
-            //         console.warn(`Active Spec Error response code : ${req.status}`)
-            //     }
-            // }
-            
-            // if (req.ok) {
-                // const data = await req.json();
-                const activeSpecTalent = data?.active_hero_talent_tree?.name;
-                const specId = data.active_specialization.id;
-                const activeSpecData = data.specializations.find(specDetails => specDetails.specialization.id == specId);
-                const activeLoadout = activeSpecData.loadouts.find(loadout => loadout.is_active == true);
 
+            const activeSpecTalent = data?.active_hero_talent_tree?.name;
+            const specId = data.active_specialization.id;
+            const activeSpecData = data.specializations.find(specDetails => specDetails.specialization.id == specId);
+            const activeLoadout = activeSpecData.loadouts.find(loadout => loadout.is_active == true);
 
-                result.talentsCode = activeLoadout ? activeLoadout.talent_loadout_code : null;
-                result.talentsSpec = activeSpecTalent ? activeSpecTalent : null;
+            result.talentsCode = activeLoadout ? activeLoadout.talent_loadout_code : null;
+            result.talentsSpec = activeSpecTalent ? activeSpecTalent : null;
 
-                return result
-            // } 
+            return result
+
         } catch (error) {
             if (Object.keys(result).length === 0) return result
             console.warn(error);
@@ -476,14 +465,8 @@ const helpFetch = {
     getTalentSpec: async function (href) {
         try {
             const data = await this.fetchBlizzard(href);
-            
-            // if(req.ok){
-                // const data = await req.json();
-                const talentString = data?.active_hero_talent_tree?.name;
-                
-                return talentString ? talentString : null;
-
-            // }
+            const talentString = data?.active_hero_talent_tree?.name;
+            return talentString ? talentString : null;
         } catch (error) {
             console.warn(error);
         }
@@ -498,10 +481,7 @@ const helpFetch = {
 
         try {
             const data = await this.fetchBlizzard(url);
-            // if (req.ok) {
-                // const data = await req.json();
-                return data?.results
-            // }
+            return data?.results
         } catch (error) {
             return null
         }

--- a/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
+++ b/src/helpers/blizFetch-helpers/endpointFetchesBliz.js
@@ -338,6 +338,23 @@ const helpFetch = {
                 'Pragma': 'no-cache'
             }
         };
+        let res;
+        let text = "D";
+        let data = null
+        let retries = 0;
+
+        while(data === null && retries < 5) { // Loop for a valid JSON
+
+            try {
+                res = await fetch(apiUrl, finalOptions);
+                text = await res.text();
+                if(!text.startsWith("D")) {
+                    data = JSON.parse(text);
+                }
+            } catch (error) {
+                await delay(1000); // Delay to give the API air
+            }
+        }
 
         return fetch(apiUrl, finalOptions)
     },

--- a/src/services/updateAchieves.js
+++ b/src/services/updateAchieves.js
@@ -11,9 +11,9 @@ export default async function updateDBAchieves() {
     const feastOfStrengthURL = `https://eu.api.blizzard.com/data/wow/achievement-category/15270?namespace=static-eu`; //!! WWI SSN3
     
     try {
-        const req = await helpFetch.fetchBlizzard(feastOfStrengthURL);
-        if (req.status == 200){
-            const data = await req.json();
+        const data = await helpFetch.fetchBlizzard(feastOfStrengthURL);
+        // if (req.status == 200){
+            // const data = await req.json();
             const achievements = data?.achievements;
             let storedAches = getSeasonalIdsMap();
             if(storedAches === null) {
@@ -36,9 +36,9 @@ export default async function updateDBAchieves() {
                             exist.href = achievement?.key?.href;
 
                             
-                            const achDataReq = await helpFetch.fetchBlizzard(achievement.key.href);
+                            const achData = await helpFetch.fetchBlizzard(achievement.key.href);
 
-                            const achData = await achDataReq.json();
+                            // const achData = await achDataReq.json();
 
                             const mediaString = await helpFetch.getMedia(achData, "media");
                             
@@ -104,7 +104,7 @@ export default async function updateDBAchieves() {
             }
             await delay(2000);
             await setSeasonalIdsMap()
-        }
+        // }
         
     } catch (error) {
         console.warn(error)

--- a/src/services/updateAchieves.js
+++ b/src/services/updateAchieves.js
@@ -12,99 +12,82 @@ export default async function updateDBAchieves() {
     
     try {
         const data = await helpFetch.fetchBlizzard(feastOfStrengthURL);
-        // if (req.status == 200){
-            // const data = await req.json();
-            const achievements = data?.achievements;
-            let storedAches = getSeasonalIdsMap();
-            if(storedAches === null) {
-                await setSeasonalIdsMap()
-                await delay(2000);
-                storedAches = getSeasonalIdsMap();
-            }
 
-            if (achievements) {
-                for (const achievement of achievements) {
-                    const stringId = String(achievement.id);
-                    let exist = storedAches.get(stringId)?._id
+        const achievements = data?.achievements;
+        let storedAches = getSeasonalIdsMap();
+        if(storedAches === null) {
+            await setSeasonalIdsMap()
+            await delay(2000);
+            storedAches = getSeasonalIdsMap();
+        }
 
-                    if (exist) {
+        if (achievements) {
+            for (const achievement of achievements) {
+                const stringId = String(achievement.id);
+                let exist = storedAches.get(stringId)?._id
+
+                if (exist) {
                         
-                        exist = exist = await Achievement.findById(exist) || undefined;
-                        if (exist.name != achievement?.name || exist.href != achievement?.key?.href || exist.media === undefined) {
+                    exist = exist = await Achievement.findById(exist) || undefined;
+                    if (exist.name != achievement?.name || exist.href != achievement?.key?.href || exist.media === undefined) {
                             
-                            exist.name = achievement?.name;;
-                            exist.href = achievement?.key?.href;
-
+                        exist.name = achievement?.name;;
+                        exist.href = achievement?.key?.href;
                             
-                            const achData = await helpFetch.fetchBlizzard(achievement.key.href);
-
-                            // const achData = await achDataReq.json();
-
-                            const mediaString = await helpFetch.getMedia(achData, "media");
+                        const achData = await helpFetch.fetchBlizzard(achievement.key.href);
+                        const mediaString = await helpFetch.getMedia(achData, "media");
                             
-                            if(mediaString) exist.media = mediaString;
-                            if(achData.description) exist.description = achData.description;
-                            if(achData.display_order) exist.displayOrder = achData.display_order;
-                            if(achData.category) exist.category = achData.category.id;
-                            if(achData.criteria) exist.criteria = achData.criteria.id;
+                        if(mediaString) exist.media = mediaString;
+                        if(achData.description) exist.description = achData.description;
+                        if(achData.display_order) exist.displayOrder = achData.display_order;
+                        if(achData.category) exist.category = achData.category.id;
+                        if(achData.criteria) exist.criteria = achData.criteria.id;
 
-                            let name = achData?.name;
+                        let name = achData?.name;
 
-                            if(name && name.includes(`: `) && name.includes(` Season `)) {
+                        if(name && name.includes(`: `) && name.includes(` Season `)) {
+                            try {
+                                const [ title, expansion ] = name.split(`: `);
+                                let expName;
+                                let seasonIndex;
+                                [ expName, seasonIndex ] = expansion.split(` Season `);
 
-                                try {
-
-                                    const [ title, expansion ] = name.split(`: `);
-
-                                    let expName;
-                                    let seasonIndex;
-                                    [ expName, seasonIndex ] = expansion.split(` Season `);
-
-                                    if(seasonIndex) {
-                                        const season = Number(seasonIndex);
-        
-                                        exist.expansion.name = expName;
-                                        exist.expansion.season = season;
-
-                                    } else {
-                                        seasonIndex = expName.replace(`Season `, "");
-                                        const season = Number(seasonIndex);
-                                        exist.expansion.season = season;
-                                    }
-
-                                    
-                                } catch (error) {
-
-                                    console.warn(error)
-                                    
+                                if(seasonIndex) {
+                                    const season = Number(seasonIndex);
+                                    exist.expansion.name = expName;
+                                    exist.expansion.season = season;
+                                } else {
+                                    seasonIndex = expName.replace(`Season `, "");
+                                    const season = Number(seasonIndex);
+                                    exist.expansion.season = season;
                                 }
 
+                            } catch (error) {
+                                console.warn(error)
                             }
 
-                            await exist.save();
                         }
-                        
-                        continue;
-
+                        await exist.save();
                     }
+                    continue;
+                }
 
-                    if(achievement.id && achievement.name && achievement.key.href) {
+                if(achievement.id && achievement.name && achievement.key.href) {
 
-                        const newAch = new Achievement({
-                            _id: achievement.id,
-                            name: achievement.name,
-                            href: achievement.key.href
-                        })
+                    const newAch = new Achievement({
+                        _id: achievement.id,
+                        name: achievement.name,
+                        href: achievement.key.href
+                    })
     
-                        await newAch.save();
-
-                    }
+                    await newAch.save();
 
                 }
+
             }
-            await delay(2000);
-            await setSeasonalIdsMap()
-        // }
+        }
+        await delay(2000);
+        await setSeasonalIdsMap()
         
     } catch (error) {
         console.warn(error)

--- a/src/services/updateRealms.js
+++ b/src/services/updateRealms.js
@@ -68,60 +68,50 @@ export default async function updateDBRealms() {
 
         try {
             const blizData = await helpFetch.fetchBlizzard(realmsExtractUrl);
-
-            // if(req.ok) {
-                // const blizData = await req.json();
                 
-                if (blizData.results && Array.isArray(blizData?.results)) {
-                    for (const { data } of blizData.results) {
+            if (blizData.results && Array.isArray(blizData?.results)) {
+                for (const { data } of blizData.results) {
 
-                        if(data) {
+                    if(data) {
                             
-                            const {realms} = data;
-                            if(Array.isArray(realms)){
-                                for (const realm of realms) {
-                                    const {timezone, name, region, id, slug} = realm;
-                                    const locale = realm?.["locale"]
+                        const {realms} = data;
+                        if(Array.isArray(realms)){
+                            for (const realm of realms) {
+                                const {timezone, name, region, id, slug} = realm;
+                                const locale = realm?.["locale"]
                                     
-                                    const zone = convertLocale(locale);
+                                const zone = convertLocale(locale);
 
-                                    const idString = String( slug + ":" + region.id);
-                                    const exist = storedRealms.has(idString);
-                                    const searchExist = storedRealmSearech.has(slug);
+                                const idString = String( slug + ":" + region.id);
+                                const exist = storedRealms.has(idString);
+                                const searchExist = storedRealmSearech.has(slug);
 
-                                    if(exist) {
-                                        if(searchExist){
-                                            continue
-                                        } else {
-                                            const realmSearchToBeInserted = storedRealms.get(idString);
-                                            await insertOneRealmSearchMap(realmSearchToBeInserted);
-                                        }
+                                if(exist) {
+                                    if(searchExist){
+                                        continue
+                                    } else {
+                                        const realmSearchToBeInserted = storedRealms.get(idString);
+                                        await insertOneRealmSearchMap(realmSearchToBeInserted);
                                     }
-                                    else {
-                                        const newRealm = new Realm();
-                                        newRealm._id = id;
-                                        newRealm.name = name;
-                                        newRealm.locale = zone;
-                                        newRealm.slug = slug;
-                                        newRealm.timezone = timezone;
-                                        newRealm.region = region?.id;
-                                        const newRealmRecived = await newRealm.save();
-                                        if(newRealmRecived) {
-                                            await insertOneRealmSearchMap(newRealmRecived.toObject());
-                                        }
+                                }
+                                else {
+                                    const newRealm = new Realm();
+                                    newRealm._id = id;
+                                    newRealm.name = name;
+                                    newRealm.locale = zone;
+                                    newRealm.slug = slug;
+                                    newRealm.timezone = timezone;
+                                    newRealm.region = region?.id;
+                                    const newRealmRecived = await newRealm.save();
+                                    if(newRealmRecived) {
+                                        await insertOneRealmSearchMap(newRealmRecived.toObject());
                                     }
-
-
                                 }
                             }
-                                
                         }
-                        
-
                     }
                 }
-
-            // }
+            }
         } catch (error) {
             console.warn(error)
         }

--- a/src/services/updateRealms.js
+++ b/src/services/updateRealms.js
@@ -67,10 +67,10 @@ export default async function updateDBRealms() {
         // const realmsExtractUrl = `https://eu.api.blizzard.com/data/wow/search/connected-realm?namespace=dynamic-eu&orderby=id`;
 
         try {
-            const req = await helpFetch.fetchBlizzard(realmsExtractUrl);
+            const blizData = await helpFetch.fetchBlizzard(realmsExtractUrl);
 
-            if(req.ok) {
-                const blizData = await req.json();
+            // if(req.ok) {
+                // const blizData = await req.json();
                 
                 if (blizData.results && Array.isArray(blizData?.results)) {
                     for (const { data } of blizData.results) {
@@ -121,7 +121,7 @@ export default async function updateDBRealms() {
                     }
                 }
 
-            }
+            // }
         } catch (error) {
             console.warn(error)
         }


### PR DESCRIPTION
Closes #2

### Changes
- Added retry logic (max 5 attempts with 1s delay) for Blizzard API fetches.
- Centralized parsing in fetchBlizzard with graceful fallback on invalid JSON.
- Persisted non-JSON responses into MongoDB (BlizAPIError model) with url, status, body, and timestamps.
- Updated schema to store structured error entries.

### Notes
- Function now returns `data` or `null` if all retries fail.
- Errors are saved in the database for later inspection and analysis.
